### PR TITLE
manually calling node-gyp is not needed anymore with recent npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "scripts": {
     "test": "expresso",
-    "watch": "coffee -c -w -o lib src",
-    "install": "node-gyp rebuild"
+    "watch": "coffee -c -w -o lib src"
   },
   "main": "./lib/nroonga",
   "engines": {


### PR DESCRIPTION
npm will run node-gyp when it finds a binding.gyp in the module, so manually calling node-gyp is not needed anymore
