### PR TITLE
Be able to build on Mac OS X

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,13 @@
       "include_dirs": ["<!@(pkg-config --cflags-only-I groonga | sed -e 's/-I//g')"],
       "ldflags": ["<!@(pkg-config --libs-only-L groonga)"],
       "libraries": ["<!@(pkg-config --libs-only-l groonga)"],
+      "conditions": [
+        ['OS == "mac"', {
+          "xcode_settings": {
+            "OTHER_LDFLAGS": ["<!@(pkg-config --libs-only-L groonga)"]
+          }
+        }]
+      ]
     }
   ]
 }


### PR DESCRIPTION
I guess `xcode_settings` property is needed to build nroonga on Mac OS X.

See more information at https://gist.github.com/1590684 commented on TooTallNate/node-gyp#55.
