### PR TITLE
[travis] Fix groonga install line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
  - '0.8'
  - '0.10'
 before_install:
- - curl https://raw.github.com/groonga/groonga/master/data/travis/setup.sh | sh
+ - curl --silent --location https://github.com/groonga/groonga/raw/master/data/travis/setup.sh | sh


### PR DESCRIPTION
Because raw.github.com is redirected.

resource:
http://sourceforge.jp/projects/groonga/lists/archive/dev/2014-April/002270.html
