### PR TITLE
Remove namespace v8

### DIFF
--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -8,7 +8,6 @@
 #include <string>
 
 using namespace v8;
-using namespace node;
 
 namespace nroonga {
 

--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -1,10 +1,7 @@
 #ifndef NROONGA_GROONGA_H
 #define NROONGA_GROONGA_H
 #include <nan.h>
-#include <uv.h>
 #include <groonga.h>
-
-#include <string>
 
 namespace nroonga {
 

--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -45,7 +45,7 @@ class Database : public Nan::ObjectWrap {
     static void CommandAfter(uv_work_t* req);
 };
 
-void InitNroonga(v8::Handle<v8::Object> target);
+void InitNroonga(v8::Local<v8::Object> exports);
 
 } // namespace nroonga
 #endif

--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -2,12 +2,9 @@
 #define NROONGA_GROONGA_H
 #include <nan.h>
 #include <uv.h>
-#include <v8.h>
 #include <groonga.h>
 
 #include <string>
-
-using namespace v8;
 
 namespace nroonga {
 
@@ -21,7 +18,7 @@ class Database : public Nan::ObjectWrap {
 
     struct Baton {
       uv_work_t request;
-      Nan::Persistent<Function> callback;
+      Nan::Persistent<v8::Function> callback;
       int error;
       char *result;
       unsigned int result_length;
@@ -32,10 +29,10 @@ class Database : public Nan::ObjectWrap {
     };
 
   protected:
-    static void New(const Nan::FunctionCallbackInfo<Value>& info);
-    static void CommandString(const Nan::FunctionCallbackInfo<Value>& info);
-    static void CommandSyncString(const Nan::FunctionCallbackInfo<Value>& info);
-    static void Close(const Nan::FunctionCallbackInfo<Value>& info);
+    static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+    static void CommandString(const Nan::FunctionCallbackInfo<v8::Value>& info);
+    static void CommandSyncString(const Nan::FunctionCallbackInfo<v8::Value>& info);
+    static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
     Database() : ObjectWrap() {
     }
     bool Cleanup();


### PR DESCRIPTION
It is because it was not used in `nan` usage examples.
https://github.com/nodejs/node-addon-examples/tree/6a51626da3438a59d31d43229cee3e6fd09ec8a5/6_object_wrap/nan



