### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "database"
   ],
   "homepage": "http://nroonga.github.com/",
+  "license": "LGPL-2.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/nroonga/nroonga.git"


### PR DESCRIPTION
The following warning.

```
npm WARN nroonga@0.3.0 No license field.
```