### PR TITLE
 Change `Nan::MakeCallback` to `AsyncResource::runInAsyncScope`

### DIFF
--- a/src/nroonga.cc
+++ b/src/nroonga.cc
@@ -167,9 +167,9 @@ void Database::CommandAfter(uv_work_t* req) {
       argv[1] = parse_value.ToLocalChecked();
     }
   }
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(),
-                    Nan::New<v8::Function>(baton->callback),
-                    argc, argv);
+  baton->runInAsyncScope(Nan::GetCurrentContext()->Global(),
+                         Nan::New<v8::Function>(baton->callback),
+                         argc, argv);
   grn_ctx_fin(&baton->context);
   delete baton;
 }

--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -13,16 +13,20 @@ class Database : public Nan::ObjectWrap {
   public:
     static void Initialize(v8::Local<v8::Object> exports);
 
-    struct Baton {
-      uv_work_t request;
-      Nan::Persistent<v8::Function> callback;
-      int error;
-      char *result;
-      unsigned int result_length;
+    class Baton : public Nan::AsyncResource {
+      public:
+        Baton() : AsyncResource("nroonga::Database::Baton") {
+        };
 
-      std::string command;
-      grn_ctx context;
-      grn_obj *database;
+        uv_work_t request;
+        Nan::Persistent<v8::Function> callback;
+        int error;
+        char *result;
+        unsigned int result_length;
+
+        std::string command;
+        grn_ctx context;
+        grn_obj *database;
     };
 
   private:


### PR DESCRIPTION
> Deprecated wrappers around the legacy node::MakeCallback() APIs. Node.js 10+ has deprecated these legacy APIs as they do not provide a mechanism to preserve async context.

https://github.com/nodejs/nan/blob/master/doc/node_misc.md#nanmakecallback