### PR TITLE
Stop supporting Node.js4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
- - '4'
  - '6'
  - '8'
  - '9'

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "main": "./lib/nroonga",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   }
 }


### PR DESCRIPTION
Node.js 4.0 is now EOL.

https://github.com/nodejs/Release#end-of-life-releases