### PR TITLE
Fix deprecated warnings

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -751,9 +751,9 @@
       }
     },
     "fs-extra": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1196,9 +1196,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "standard": "^12.0.1"
   },
   "dependencies": {
-    "nan": "^2.11.1"
+    "nan": "^2.12.1"
   },
   "files": [
     "README.md",

--- a/src/nroonga.cc
+++ b/src/nroonga.cc
@@ -11,17 +11,17 @@ v8::Local<v8::String> Database::optionsToCommandString(
     return Nan::New("").ToLocalChecked();
   }
   if (info.Length() == 1) {
-    return info[0]->ToString();
+    return info[0].As<v8::String>();
   }
   if (info.Length() >= 2 && !info[1]->IsObject()) {
-    return info[0]->ToString();
+    return info[0].As<v8::String>();
   }
 
-  v8::Local<v8::Object> options = info[1]->ToObject();
+  v8::Local<v8::Object> options = info[1].As<v8::Object>();
   v8::Local<v8::Array> props =
     Nan::GetOwnPropertyNames(options).ToLocalChecked();
 
-  v8::Local<v8::String> commandString = info[0]->ToString();
+  v8::Local<v8::String> commandString = info[0].As<v8::String>();
   Nan::JSON NanJSON;
   for (int i = 0, l = props->Length(); i < l; i++) {
     v8::Local<v8::Value> key = props->Get(i);
@@ -32,12 +32,13 @@ v8::Local<v8::String> Database::optionsToCommandString(
 
     commandString = v8::String::Concat(commandString,
                                        Nan::New(" --").ToLocalChecked());
-    commandString = v8::String::Concat(commandString, key->ToString());
+    commandString = v8::String::Concat(commandString, key.As<v8::String>());
     commandString = v8::String::Concat(commandString,
                                        Nan::New(" ").ToLocalChecked());
     commandString = v8::String::Concat(
         commandString,
-        NanJSON.Stringify(value->ToObject()).ToLocalChecked()->ToString());
+        NanJSON.Stringify(
+            value.As<v8::Object>()).ToLocalChecked().As<v8::String>());
   }
   return commandString;
 }
@@ -70,7 +71,7 @@ void Database::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   if (info[0]->IsUndefined()) {
     db->database = grn_db_create(ctx, NULL, NULL);
   } else if (info[0]->IsString()) {
-    Nan::Utf8String path(info[0]->ToString());
+    Nan::Utf8String path(info[0].As<v8::String>());
     if (info.Length() > 1 && info[1]->IsTrue()) {
       db->database = grn_db_open(ctx, *path);
     } else {


### PR DESCRIPTION
- Upgrade nan
- Fix deprecated warnings
```
% node -v
v11.6.0
```

Example of warning.

```
../src/nroonga.cc:14:30: warning: ‘v8::Local<v8::String> v8::Value::ToString() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
     return info[0]->ToString();
```