### PR TITLE
 Fix deprecation of 'v8::String::Concat()'

### DIFF
--- a/src/nroonga.cc
+++ b/src/nroonga.cc
@@ -4,7 +4,7 @@ namespace nroonga {
 
 Nan::Persistent<v8::Function> groonga_context_constructor;
 
-v8::Local<v8::String> Database::optionsToCommandString(
+v8::Local<v8::String> Database::OptionsToCommandString(
     const Nan::FunctionCallbackInfo<v8::Value>& info) {
   if (info.Length() < 1 || !info[0]->IsString()) {
     Nan::ThrowTypeError("Bad parameter");
@@ -212,7 +212,7 @@ void Database::Command(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   baton->request.data = baton;
   baton->callback.Reset(callback);
 
-  Nan::Utf8String command(optionsToCommandString(info));
+  Nan::Utf8String command(OptionsToCommandString(info));
   baton->database = db->database;
 
   baton->command = std::string(*command, command.length());
@@ -236,7 +236,7 @@ void Database::CommandSync(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   char *result;
   unsigned int result_length;
   int flags;
-  Nan::Utf8String command(optionsToCommandString(info));
+  Nan::Utf8String command(OptionsToCommandString(info));
 
   if (db->closed) {
     Nan::ThrowTypeError("Database already closed");

--- a/src/nroonga.cc
+++ b/src/nroonga.cc
@@ -4,6 +4,15 @@ namespace nroonga {
 
 Nan::Persistent<v8::Function> groonga_context_constructor;
 
+v8::Local<v8::String> Database::Concat(
+    v8::Local<v8::String> left, v8::Local<v8::String> right) {
+#if NODE_MAJOR_VERSION >= 10
+  return v8::String::Concat(v8::Isolate::GetCurrent(), left, right);
+#else
+  return v8::String::Concat(left, right);
+#endif
+}
+
 v8::Local<v8::String> Database::OptionsToCommandString(
     const Nan::FunctionCallbackInfo<v8::Value>& info) {
   if (info.Length() < 1 || !info[0]->IsString()) {
@@ -30,12 +39,10 @@ v8::Local<v8::String> Database::OptionsToCommandString(
       continue;
     }
 
-    commandString = v8::String::Concat(commandString,
-                                       Nan::New(" --").ToLocalChecked());
-    commandString = v8::String::Concat(commandString, key.As<v8::String>());
-    commandString = v8::String::Concat(commandString,
-                                       Nan::New(" ").ToLocalChecked());
-    commandString = v8::String::Concat(
+    commandString = Concat(commandString, Nan::New(" --").ToLocalChecked());
+    commandString = Concat(commandString, key.As<v8::String>());
+    commandString = Concat(commandString, Nan::New(" ").ToLocalChecked());
+    commandString = Concat(
         commandString,
         NanJSON.Stringify(
             value.As<v8::Object>()).ToLocalChecked().As<v8::String>());

--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -34,6 +34,8 @@ class Database : public Nan::ObjectWrap {
     static void Command(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void CommandSync(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
+    static v8::Local<v8::String> Concat(
+        v8::Local<v8::String> left, v8::Local<v8::String> right);
     static v8::Local<v8::String> OptionsToCommandString(
         const Nan::FunctionCallbackInfo<v8::Value>& info);
     Database() : ObjectWrap() {

--- a/src/nroonga.h
+++ b/src/nroonga.h
@@ -34,7 +34,7 @@ class Database : public Nan::ObjectWrap {
     static void Command(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void CommandSync(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
-    static v8::Local<v8::String> optionsToCommandString(
+    static v8::Local<v8::String> OptionsToCommandString(
         const Nan::FunctionCallbackInfo<v8::Value>& info);
     Database() : ObjectWrap() {
     }


### PR DESCRIPTION
The following warning.

```
../src/nroonga.cc: In static member function ‘static v8::Local<v8::String> nroonga::Database::Concat(v8::Local<v8::String>, v8::Local<v8::String>)’:
../src/nroonga.cc:9:40: warning: ‘static v8::Local<v8::String> v8::String::Concat(v8::Local<v8::String>, v8::Local<v8::String>)’ is deprecated: Use Isolate* version [-Wdeprecated-declarations]
   return v8::String::Concat(left, right);
```