### PR TITLE
Remove 'sudo' settings from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
-sudo: required
 before_install:
  - curl --silent --location https://github.com/groonga/groonga/raw/master/data/travis/setup.sh | sh


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration