### PR TITLE
appveyor: test extended path prefix \\?\ test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ addons:
       - g++-4.8
 before_install:
  - curl --silent --location https://github.com/groonga/groonga/raw/master/data/travis/setup.sh | sh
+ - sudo apt-get install -qq -y groonga-normalizer-mysql groonga-tokenizer-mecab

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,12 @@ install:
   # setup groonga archive at c:/projects/groonga
   - choco install -y curl 7zip.commandline
   - cd %APPVEYOR_BUILD_FOLDER%/..
-  - set ARCHIVE=groonga-latest-%PLATFORM%-vs2017.zip
-  - curl -O https://packages.groonga.org/windows/groonga/%ARCHIVE%
+  # Enable after Groonga 9.0.3 has been released.
+  #- set ARCHIVE=groonga-latest-%PLATFORM%-vs2017.zip
+  #- curl -O https://packages.groonga.org/windows/groonga/%ARCHIVE%
+  # Use master to test fixed \\?\ expanded path prefix issue.
+  - set ARCHIVE=groonga-9.0.3-65dc3cd-%Platform%.zip
+  - curl -O https://packages.groonga.org/tmp/%ARCHIVE%
   - 7z x %ARCHIVE%
   - del %ARCHIVE%
   - move groonga-* groonga
@@ -41,6 +45,13 @@ build: off
 test_script:
   - node --version
   - npm --version
+  # Test with GROONGA_PATH
+  - npm test
+  # Test without GROONGA_PATH
+  # Reproduce extended path prefix \\?\ test case (failed to load Groonga plugin)
+  - set GROONGA_PATH=
+  - xcopy /Q /E /I /Y %APPVEYOR_BUILD_FOLDER%\..\groonga\* build\Release\
+  - xcopy /Q /E /I /Y build\Release\bin\* build\Release\
   - npm test
 
 #on_failure:

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,42 @@
+/* eslint no-unused-expressions: 0 */
+'use strict'
+
+const fs = require('fs-extra')
+const path = require('path')
+const expect = require('chai').expect
+const nroonga = require('../lib/nroonga')
+
+/* global beforeEach, afterEach, describe, it */
+describe('plugin', () => {
+  let db = null
+  const tempdir = path.join('test', 'tmp')
+  const databaseName = `tempdb-${process.pid}-${(new Date()).valueOf()}`
+
+  beforeEach(() => {
+    if (!fs.existsSync(tempdir)) fs.mkdirSync(tempdir)
+    db = new nroonga.Database(path.join(tempdir, databaseName))
+    db.commandSync('plugin_register normalizers/mysql')
+    db.commandSync('plugin_register ruby/eval')
+  })
+
+  afterEach(() => {
+    db.close()
+    fs.removeSync(tempdir)
+  })
+
+  describe('Normalizer MySQL', () => {
+    it('should normalize haha', () => {
+      const matched = db.commandSync('normalize NormalizerMySQLUnicode900 "はハ"')
+      const expected = { 'normalized': 'はは', 'types': [], 'checks': [] }
+      expect(matched).to.deep.equal(expected)
+    })
+  })
+
+  describe('Ruby', () => {
+    it('should evaluate ruby script', () => {
+      const matched = db.commandSync('ruby_eval "1 + 2"')
+      const expected = { 'value': 3 }
+      expect(matched).to.deep.equal(expected)
+    })
+  })
+})


### PR DESCRIPTION
When Groonga plugin module is located under build/Release/*,
it fails to load plugin because of libgroonga.dll can't handle
extended path prefix \\?\ correctly which GetModuleFileNameW returns
it.

If libgroonga.dll has loaded from GROONGA_PATH, it doesn't occur,
so added test case 1. with GROONGA_PATH and 2. without GROONGA_PATH.

Related issue: https://github.com/groonga/groonga/issues/958