### PR TITLE
Modify version of AppVeyor's Node.js

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2017
 
 environment:
   matrix:
-    - nodejs_version: '11' # 12 is not ready on AppVeyor
+    - nodejs_version: '12'
     - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'


### PR DESCRIPTION
11 -> 12

AppVeyor can use Node.js12.