### PR TITLE
Fix definition error of `nroonga.d.ts`

### DIFF
--- a/examples/test.ts
+++ b/examples/test.ts
@@ -1,0 +1,13 @@
+import { Database } from '..'
+
+const db = new Database()
+
+// Synchronous
+console.log('// Synchronous')
+console.log(db.commandSync('status'))
+
+// Asynchronous
+db.command('status', (_, data) => {
+  console.log('// Asynchronous')
+  console.log(data)
+})

--- a/types/nroonga.d.ts
+++ b/types/nroonga.d.ts
@@ -1,6 +1,6 @@
 declare namespace nroonga {
   interface CallbackType {
-    (error: Error, data: any) => void
+    (error: Error, data: any): void
   }
 
   class Database {


### PR DESCRIPTION
I got an error.

```
% tsc types/nroonga.d.ts
types/nroonga.d.ts:3:31 - error TS1005: ':' expected.

3     (error: Error, data: any) => void
                                ~~


Found 1 error.
```

Also add a simple TypeScript example.

