### PR TITLE
Drop Node.js 8.x support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   "main": "./lib/nroonga",
   "types": "./types/nroonga.d.ts",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   }
 }


### PR DESCRIPTION
* Node.js 8 is EOL.
    * https://github.com/nodejs/Release#end-of-life-releases
* The latest version of npm does not support Node.js8.
    * `npm WARN npm npm does not support Node.js v8.17.0`