### PR TITLE
ci: use windows-2022 explicitly

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
         npm test
 
   windows-test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
         del %ARCHIVE%
         move groonga-* ..\groonga
     - run: npm i -g npm
-    - run: npm config set msvs_version 2019
+    - run: npm config set msvs_version 2022
     - run: npm i -g node-gyp
     - name: Install Nroonga
       shell: cmd


### PR DESCRIPTION
'windows-latest' is the transition period from '2019' to '2022'.
So we do not know which one it will be.

https://github.blog/changelog/2021-11-16-github-actions-windows-server-2022-with-visual-studio-2022-is-now-generally-available-on-github-hosted-runners/