### PR TITLE
Update CI settings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
         npm test
 
   windows-test:
-    runs-on: windows-2022
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,6 @@ jobs:
         del %ARCHIVE%
         move groonga-* ..\groonga
     - run: npm i -g npm
-    - run: npm config set msvs_version 2022
     - run: npm i -g node-gyp
     - name: Install Nroonga
       shell: cmd


### PR DESCRIPTION
* ci: drop 12.x from node-version
    * 12 is EOL.
* ci: change windows image to 'windows-latest'
    * The windows-latest label currently uses the Windows Server 2022 runner image.
* ci: delete unnecessary configuration commands
    * The following error occurred. ```npm ERR! `msvs_version` is not a valid npm option```
    * It continues to fail only on Windows 14.x, but I believe this will be fixed when the image is updated in the future.
