### PR TITLE
ci: use npm already installed on windows

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,7 +44,6 @@ jobs:
         7z x %ARCHIVE%
         del %ARCHIVE%
         move groonga-* ..\groonga
-    - run: npm i -g npm
     - run: npm i -g node-gyp
     - name: Install Nroonga
       shell: cmd


### PR DESCRIPTION
The latest npm may not support the version of Node.js used in CI.

https://github.com/nroonga/nroonga/actions/runs/6218329794/job/16874657692?pr=103