### PR TITLE
ci: add 22.x to node-version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@master
     - name: Use Node.js ${{ matrix.node-version }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -18,6 +18,7 @@
           "libraries": ["<!@(pkg-config --libs-only-l groonga)"],
         }],
         ['OS=="win"', {
+          "defines": ["NOMINMAX"],
           "include_dirs": [
             "<!(echo %GROONGA_PATH%)/include",
             "<!(echo %GROONGA_PATH%)/include/groonga",


### PR DESCRIPTION
* 16.x is EOL, so it is dropped
* Add `"defines": ["NOMINMAX"]`
  * We got this error in Windows: 
    ```
    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): warning C4003: not enough arguments for function-like macro invocation 'min' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): warning C4003: not enough arguments for function-like macro invocation 'max' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): error C2589: '(': illegal token on right side of '::' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): error C2760: syntax error: ')' was unexpected here; expected 'expression' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): error C2760: syntax error: ')' was unexpected here; expected ';' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): error C3878: syntax error: unexpected token ')' following 'expression_statement' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): message : error recovery skipped: ') <' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): message : error recovery skipped: ') ) ?' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): message : error recovery skipped: ') :' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(408,62): message : error recovery skipped: ') ) )  . . . )' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): error C2589: '(': illegal token on right side of '::' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): error C2760: syntax error: ')' was unexpected here; expected 'expression' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): error C2760: syntax error: ')' was unexpected here; expected ';' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): error C3878: syntax error: unexpected token ')' following 'expression_statement' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): message : error recovery skipped: ') >' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): message : error recovery skipped: ') ) ?' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): message : error recovery skipped: ') :' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    C:\Users\runneradmin\AppData\Local\node-gyp\Cache\22.1.0\include\node\v8-function-callback.h(409,62): message : error recovery skipped: ') ) )  . . . )' [D:\a\nroonga\nroonga\build\nroonga_bindings.vcxproj]
      (compiling source file '../src/nroonga.cc')

    gyp ERR! build error
    gyp ERR! stack Error: `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
    gyp ERR! stack at ChildProcess.<anonymous> (C:\hostedtoolcache\windows\node\22.1.0\x64\node_modules\npm\node_modules\node-gyp\lib\build.js:209:23)
    gyp ERR! stack at ChildProcess.emit (node:events:520:28)
    gyp ERR! stack at ChildProcess._handle.onexit (node:internal/child_process:294:12)
    gyp ERR! System Windows_NT 10.0.20348
    gyp ERR! command "C:\\hostedtoolcache\\windows\\node\\22.1.0\\x64\\node.exe" "C:\\hostedtoolcache\\windows\\node\\22.1.0\\x64\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
    gyp ERR! cwd D:\a\nroonga\nroonga
    gyp ERR! node -v v22.1.0
    gyp ERR! node-gyp -v v10.1.0
    gyp ERR! not ok
    npm error code 1
    npm error path D:\a\nroonga\nroonga
    npm error command failed
    npm error command C:\Windows\system32\cmd.exe /d /s /c node-gyp rebuild

    npm error A complete log of this run can be found in: C:\npm\cache\_logs\2024-05-05T05_55_37_796Z-debug-0.log
    ```