### PR TITLE
ci windows: Use the vs2022 package

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,14 +37,14 @@ jobs:
     - name: Install Groonga
       shell: cmd
       run: |
-        set ARCHIVE=groonga-latest-x64-vs2019.zip
+        set ARCHIVE=groonga-latest-x64-vs2022.zip
 
         choco install -y curl 7zip.commandline
         curl -OL https://packages.groonga.org/windows/groonga/%ARCHIVE%
         7z x %ARCHIVE%
         del %ARCHIVE%
         move groonga-* ..\groonga
-    - run: npm i -g node-gyp
+    - run: npm i -g npm node-gyp
     - name: Install Nroonga
       shell: cmd
       run: |


### PR DESCRIPTION
vs2019 is no longer supported.
https://groonga.org/docs/news/15.html#windows-drop-support-for-groonga-package-that-is-built-with-visual-studio-2019